### PR TITLE
Improve error message for drone position validation

### DIFF
--- a/DSSE/environment/env_base.py
+++ b/DSSE/environment/env_base.py
@@ -101,7 +101,7 @@ class DroneSwarmSearchBase(ABC, ParallelEnv):
         if drones_positions is not None:
             if not self.is_valid_position_drones(drones_positions):
                 raise ValueError(
-                    "You are trying to place the drone in a invalid position"
+                    f"You are trying to place the drone in a invalid position: {drones_positions}"
                 )
 
         self.agents = copy(self.possible_agents)


### PR DESCRIPTION
Updated error message for invalid drone position.

Using RLlib it's difficult to understand which combinations of positions cause exception.