### PR TITLE
Replacing pfeinsper/drone-swarm-search by capstone-insper/drone-swarm-search

### DIFF
--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x  # Choose the desired Python version
+          python-version: '3.12'
       
       - name: Cache Python Dependencies
         uses: actions/cache@v4
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt upgrade
-          sudo apt-get install -y libgdal-dev gdal-bin
+          sudo apt-get install -y libgdal-dev gdal-bin libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run Pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We're thrilled that you're interested in contributing to our project. Your invol
 
 Here’s how you can contribute:
 
-1. **Explore our issues**: Start by looking through the [issues](https://github.com/pfeinsper/drone-swarm-search/issues) on our GitHub repository.
+1. **Explore our issues**: Start by looking through the [issues](https://github.com/capstone-insper/drone-swarm-search/issues) on our GitHub repository.
 
 2. **Fork and clone the repository**: Once you've found an issue to work on, fork the repository and then clone it to your local machine so you can start your work.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Tests Status 🧪](https://github.com/pfeinsper/drone-swarm-search/actions/workflows/env.yml/badge.svg)](https://github.com/pfeinsper/drone-swarm-search/actions/workflows/env.yml)
-[![Docs Deployment 📝](https://github.com/pfeinsper/drone-swarm-search/actions/workflows/deploy.yml/badge.svg?branch=vitepress_docs)](https://github.com/pfeinsper/drone-swarm-search/actions/workflows/deploy.yml)
+[![Tests Status 🧪](https://github.com/capstone-insper/drone-swarm-search/actions/workflows/env.yml/badge.svg)](https://github.com/capstone-insper/drone-swarm-search/actions/workflows/env.yml)
+[![Docs Deployment 📝](https://github.com/capstone-insper/drone-swarm-search/actions/workflows/deploy.yml/badge.svg?branch=vitepress_docs)](https://github.com/capstone-insper/drone-swarm-search/actions/workflows/deploy.yml)
 [![PyPI Release 🚀](https://badge.fury.io/py/DSSE.svg)](https://badge.fury.io/py/DSSE)
-[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg?style=flat)](https://github.com/pfeinsper/drone-swarm-search/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg?style=flat)](https://github.com/capstone-insper/drone-swarm-search/blob/main/LICENSE)
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.22.3-blue)]()
 [![DOI](https://zenodo.org/badge/599323572.svg)](https://zenodo.org/doi/10.5281/zenodo.12659847)
 [![JOSS DOI](https://joss.theoj.org/papers/10.21105/joss.06746/status.svg)](https://doi.org/10.21105/joss.06746)
-![GitHub stars](https://img.shields.io/github/stars/pfeinsper/drone-swarm-search)
+![GitHub stars](https://img.shields.io/github/stars/capstone-insper/drone-swarm-search)
 [![Downloads](https://static.pepy.tech/badge/dsse)](https://pepy.tech/project/dsse)
 
-# <img src="https://raw.githubusercontent.com/pfeinsper/drone-swarm-search/main/docs/public/pics/drone.svg" alt="DSSE Icon" width="45" height="25"> Drone Swarm Search Environment (DSSE)
+# <img src="https://raw.githubusercontent.com/capstone-insper/drone-swarm-search/main/docs/public/pics/drone.svg" alt="DSSE Icon" width="45" height="25"> Drone Swarm Search Environment (DSSE)
 
 Welcome to the official GitHub repository for the Drone Swarm Search Environment (DSSE). This project offers a comprehensive simulation platform designed for developing, testing, and refining search strategies using drone swarms. Researchers and developers will find a versatile toolset supporting a broad spectrum of simulations, which facilitates the exploration of complex drone behaviors and interactions in dynamic, real-world scenarios.
 
@@ -17,9 +17,9 @@ In this repository, we have implemented two distinct types of environments. The 
 
 ## 📚 Documentation Links
 
-- **[Documentation Site](https://pfeinsper.github.io/drone-swarm-search/)**: Access comprehensive documentation including tutorials, and usage examples for the Drone Swarm Search Environment (DSSE). Ideal for users seeking detailed information about the project's capabilities and how to integrate them into their own applications.
+- **[Documentation Site](https://capstone-insper.github.io/drone-swarm-search/)**: Access comprehensive documentation including tutorials, and usage examples for the Drone Swarm Search Environment (DSSE). Ideal for users seeking detailed information about the project's capabilities and how to integrate them into their own applications.
 
-- **[Algorithm Details](https://github.com/pfeinsper/drone-swarm-search-algorithms)**: Explore in-depth discussions and source code for the algorithms powering the DSSE. This section is perfect for developers interested in the technical underpinnings and enhancements of the search algorithms.
+- **[Algorithm Details](https://github.com/capstone-insper/drone-swarm-search-algorithms)**: Explore in-depth discussions and source code for the algorithms powering the DSSE. This section is perfect for developers interested in the technical underpinnings and enhancements of the search algorithms.
 
 - **[PyPI Repository](https://pypi.org/project/DSSE/)**: Visit the PyPI page for DSSE to download the latest release, view release histories, and read additional installation instructions.
 
@@ -27,7 +27,7 @@ In this repository, we have implemented two distinct types of environments. The 
 
 ## 🎥 Visual Demonstrations
 <p align="center">
-    <img src="https://raw.githubusercontent.com/pfeinsper/drone-swarm-search/main/docs/public/gifs/render_with_grid_gradient.gif" width="400" height="400" align="center">
+    <img src="https://raw.githubusercontent.com/capstone-insper/drone-swarm-search/main/docs/public/gifs/render_with_grid_gradient.gif" width="400" height="400" align="center">
     <br>
     <em>Above: A simulation showing how drones adjust their search pattern over a grid.</em>
 </p>
@@ -96,7 +96,7 @@ while not done:
 
 ## 🎥 Visual Demonstrations
 <p align="center">
-    <img src="https://raw.githubusercontent.com/pfeinsper/drone-swarm-search/main/docs/public/gifs/basic_coverage.gif" width="400" height="400" align="center">
+    <img src="https://raw.githubusercontent.com/capstone-insper/drone-swarm-search/main/docs/public/gifs/basic_coverage.gif" width="400" height="400" align="center">
     <br>
     <em>Above: A simulation showing how drones adjust their search pattern over a grid.</em>
 </p>

--- a/codemeta.json
+++ b/codemeta.json
@@ -74,7 +74,7 @@
     }
   ],
   "identifier": "",
-  "codeRepository": "https://github.com/pfeinsper/drone-swarm-search",
+  "codeRepository": "https://github.com/capstone-insper/drone-swarm-search",
   "datePublished": "2024-04-25",
   "dateModified": "2024-04-25",
   "dateCreated": "2024-04-25",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/pfeinsper/drone-swarm-search', ariaLabel: 'Github link' },
+      { icon: 'github', link: 'https://github.com/capstone-insper/drone-swarm-search', ariaLabel: 'Github link' },
       
       {
         icon: {

--- a/docs/Documentation/docsAlgorithms.md
+++ b/docs/Documentation/docsAlgorithms.md
@@ -2,7 +2,7 @@
 
 ## About
 
-Welcome to our [Algorithms repository](https://github.com/pfeinsper/drone-swarm-search-algorithms)! These algorithms are specifically tailored for the environments available in `DSSE`, aimed at optimizing drone swarm coordination and search efficiency.
+Welcome to our [Algorithms repository](https://github.com/capstone-insper/drone-swarm-search-algorithms)! These algorithms are specifically tailored for the environments available in `DSSE`, aimed at optimizing drone swarm coordination and search efficiency.
 
 Explore a diverse range of implementations that leverage the latest advancements in machine learning to solve complex coordination tasks in dynamic and unpredictable environments. Our repository offers state-of-the-art solutions designed to enhance the performance and adaptability of autonomous drone swarms, making them more efficient and effective in various search and rescue missions.
 
@@ -326,7 +326,7 @@ The following table provides the settings for the coverage environment used in t
 
 ## How to Run
 
-To run the experiments, you will need to navigate to the [algorithms directory](https://github.com/pfeinsper/drone-swarm-search-algorithms) and execute scripts located in the `src/` folder. Below is a brief description of the relevant scripts and the instructions on how to run them for each hypothesis testing.
+To run the experiments, you will need to navigate to the [algorithms directory](https://github.com/capstone-insper/drone-swarm-search-algorithms) and execute scripts located in the `src/` folder. Below is a brief description of the relevant scripts and the instructions on how to run them for each hypothesis testing.
 
 ```bash
 src/
@@ -430,7 +430,7 @@ These instructions provide a comprehensive guide on how to set up and run experi
 
 ## Stay Updated
 
-We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `algorithms`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/pfeinsper/drone-swarm-search-algorithms/issues).
+We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `algorithms`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/capstone-insper/drone-swarm-search-algorithms/issues).
 
 ## License
 This documentation is licensed under the terms of the [MIT License](https://opensource.org/licenses/MIT). See the LICENSE file for more details.

--- a/docs/Documentation/docsCoverage.md
+++ b/docs/Documentation/docsCoverage.md
@@ -31,7 +31,7 @@ After instancing the environment class, the beginning of simulation might take a
 `pip install DSSE[coverage]`
 
 #### Use
-::: details Click me to view the code <a href="https://github.com/pfeinsper/drone-swarm-search/blob/main/basic_coverage.py" target="blank" style="float:right"><Badge type="tip" text="basic_coverage.py &boxbox;" /></a>
+::: details Click me to view the code <a href="https://github.com/capstone-insper/drone-swarm-search/blob/main/basic_coverage.py" target="blank" style="float:right"><Badge type="tip" text="basic_coverage.py &boxbox;" /></a>
 ```python
 from DSSE import CoverageDroneSwarmSearch
 
@@ -358,7 +358,7 @@ The `env.save_matrix()` method is not only convenient for saving the probability
 
 ## Stay Updated
 
-We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `Coverage Environment`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/pfeinsper/drone-swarm-search/issues).
+We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `Coverage Environment`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/capstone-insper/drone-swarm-search/issues).
 
 ## License
 This documentation is licensed under the terms of the [MIT License](https://opensource.org/licenses/MIT). See the LICENSE file for more details.

--- a/docs/Documentation/docsSearch.md
+++ b/docs/Documentation/docsSearch.md
@@ -28,7 +28,7 @@ The DSSE project requires Python version 3.10.5 or higher.
 `pip install DSSE`
 
 #### Use
-::: details Click me to view the code <a href="https://github.com/pfeinsper/drone-swarm-search/blob/main/basic_env.py" target="blank" style="float:right"><Badge type="tip" text="basic_env.py &boxbox;" /></a>
+::: details Click me to view the code <a href="https://github.com/capstone-insper/drone-swarm-search/blob/main/basic_env.py" target="blank" style="float:right"><Badge type="tip" text="basic_env.py &boxbox;" /></a>
 ```python
 from DSSE import DroneSwarmSearch
 
@@ -343,7 +343,7 @@ If you use this package, please consider citing it with this piece of BibTeX:
 
 ## Stay Updated
 
-We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `Search Environment`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/pfeinsper/drone-swarm-search/issues).
+We appreciate your patience and interest in our work. If you have any questions or need immediate assistance regarding our `Search Environment`, please do not hesitate to contact us via our [GitHub Issues page](https://github.com/capstone-insper/drone-swarm-search/issues).
 
 ## License
 This documentation is licensed under the terms of the [MIT License](https://opensource.org/licenses/MIT). See the LICENSE file for more details.

--- a/docs/QuickStart/quickStart.md
+++ b/docs/QuickStart/quickStart.md
@@ -17,7 +17,7 @@ pip install DSSE
 ### Basic Usage
 The following code snippet demonstrates how to set up and run the `DroneSwarmSearch` environment. Expand the details to view the code.
 
-::: details Click me to view the code <a href="https://github.com/pfeinsper/drone-swarm-search/blob/main/basic_env.py" target="blank" style="float:right"><Badge type="tip" text="basic_env.py &boxbox;" /></a>
+::: details Click me to view the code <a href="https://github.com/capstone-insper/drone-swarm-search/blob/main/basic_env.py" target="blank" style="float:right"><Badge type="tip" text="basic_env.py &boxbox;" /></a>
 ```python
 from DSSE import DroneSwarmSearch
 
@@ -90,7 +90,7 @@ pip install DSSE[coverage]
 ### Basic Usage
 The following example shows how to initiate and interact with the `CoverageDroneSwarmSearch` environment. Expand the details to see the code.
 
-::: details Click me to view the code <a href="https://github.com/pfeinsper/drone-swarm-search/blob/main/basic_coverage.py" target="blank" style="float:right"><Badge type="tip" text="basic_coverage.py &boxbox;" /></a>
+::: details Click me to view the code <a href="https://github.com/capstone-insper/drone-swarm-search/blob/main/basic_coverage.py" target="blank" style="float:right"><Badge type="tip" text="basic_coverage.py &boxbox;" /></a>
 ```python
 from DSSE import CoverageDroneSwarmSearch
 

--- a/paper.bib
+++ b/paper.bib
@@ -128,7 +128,7 @@
   author  = {Ricardo Ribeiro Rodrigues and Jorás Custódio Campos de Oliveira and Pedro Henrique Britto Aragão Andrade and Renato Laffranchi Falcão},
   title   = {Algorithms for Drone Swarm Search (DSSE)},
   year    = {2024},
-  url     = {https://github.com/pfeinsper/drone-swarm-search-algorithms}
+  url     = {https://github.com/capstone-insper/drone-swarm-search-algorithms}
 }
 
 @article{dqn2015,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,10 @@ coverage = [
 ]
 
 [project.urls]
-Homepage = "https://pfeinsper.github.io/drone-swarm-search/"
-Repository = "https://github.com/pfeinsper/drone-swarm-search/"
-Documentation = "https://pfeinsper.github.io/drone-swarm-search/"
-"Bug Report" = "https://github.com/pfeinsper/drone-swarm-search/issues/"
+Homepage = "https://capstone-insper.github.io/drone-swarm-search/"
+Repository = "https://github.com/capstone-insper/drone-swarm-search/"
+Documentation = "https://capstone-insper.github.io/drone-swarm-search/"
+"Bug Report" = "https://github.com/capstone-insper/drone-swarm-search/issues/"
 
 [tool.setuptools]
 include-package-data = true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-download_url = f"https://github.com/pfeinsper/drone-swarm-search/archive/refs/tags/v{{VERSION_PLACEHOLDER}}.tar.gz"
+download_url = f"https://github.com/capstone-insper/drone-swarm-search/archive/refs/tags/v{{VERSION_PLACEHOLDER}}.tar.gz"
 setup(
     version="{{VERSION_PLACEHOLDER}}",
     download_url=download_url,


### PR DESCRIPTION
The organization name pfeinsper was changed to capstone-insper. In some documents and other resources we are still calling https://pfeinsper.github.io/drone-swarm-search/. The result is a 404 http error. 

To fix this issue, this PR is replacing pfeinsper/drone-swarm-search by capstone-insper/drone-swarm-search-search in all documentation and setup files. 

